### PR TITLE
BUG: Fix identification of deserialized np.nan

### DIFF
--- a/missingpy/knnimpute.py
+++ b/missingpy/knnimpute.py
@@ -17,6 +17,8 @@ from .pairwise_external import pairwise_distances
 from .pairwise_external import _get_mask
 from .pairwise_external import _MASKED_METRICS
 
+from .utils import is_nan
+
 __all__ = [
     'KNNImputer',
 ]
@@ -193,8 +195,7 @@ class KNNImputer(BaseEstimator, TransformerMixin):
         """
 
         # Check data integrity and calling arguments
-        force_all_finite = False if self.missing_values in ["NaN",
-                                                            np.nan] else True
+        force_all_finite = not is_nan(self.missing_values)
         if not force_all_finite:
             if self.metric not in _MASKED_METRICS and not callable(
                     self.metric):
@@ -250,8 +251,7 @@ class KNNImputer(BaseEstimator, TransformerMixin):
         """
 
         check_is_fitted(self, ["fitted_X_", "statistics_"])
-        force_all_finite = False if self.missing_values in ["NaN",
-                                                            np.nan] else True
+        force_all_finite = not is_nan(self.missing_values)
         X = check_array(X, accept_sparse=False, dtype=FLOAT_DTYPES,
                         force_all_finite=force_all_finite, copy=self.copy)
 

--- a/missingpy/missforest.py
+++ b/missingpy/missforest.py
@@ -13,6 +13,8 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 
 from .pairwise_external import _get_mask
 
+from .utils import is_nan
+
 __all__ = [
     'MissForest',
 ]
@@ -434,9 +436,7 @@ class MissForest(BaseEstimator, TransformerMixin):
         """
 
         # Check data integrity and calling arguments
-        force_all_finite = False if self.missing_values in ["NaN",
-                                                            np.nan] else True
-
+        force_all_finite = not is_nan(self.missing_values)
         X = check_array(X, accept_sparse=False, dtype=np.float64,
                         force_all_finite=force_all_finite, copy=self.copy)
 
@@ -499,8 +499,7 @@ class MissForest(BaseEstimator, TransformerMixin):
         check_is_fitted(self, ["cat_vars_", "num_vars_", "statistics_"])
 
         # Check data integrity
-        force_all_finite = False if self.missing_values in ["NaN",
-                                                            np.nan] else True
+        force_all_finite = not is_nan(self.missing_values)
         X = check_array(X, accept_sparse=False, dtype=np.float64,
                         force_all_finite=force_all_finite, copy=self.copy)
 

--- a/missingpy/pairwise_external.py
+++ b/missingpy/pairwise_external.py
@@ -48,7 +48,7 @@ from sklearn.metrics.pairwise import PAIRWISE_DISTANCE_FUNCTIONS
 from sklearn.metrics.pairwise import _parallel_pairwise
 from sklearn.utils import check_array
 
-from .utils import masked_euclidean_distances
+from .utils import is_nan, masked_euclidean_distances
 
 _MASKED_METRICS = ['masked_euclidean']
 _VALID_METRICS += ['masked_euclidean']
@@ -56,7 +56,7 @@ _VALID_METRICS += ['masked_euclidean']
 
 def _get_mask(X, value_to_mask):
     """Compute the boolean mask X == missing_values."""
-    if value_to_mask == "NaN" or np.isnan(value_to_mask):
+    if is_nan(value_to_mask):
         return np.isnan(X)
     else:
         return X == value_to_mask

--- a/missingpy/utils.py
+++ b/missingpy/utils.py
@@ -4,6 +4,8 @@
 
 import numpy as np
 
+def is_nan(n):
+    return n == "NaN" or isinstance(n, float) and np.isnan(n)
 
 def masked_euclidean_distances(X, Y=None, squared=False,
                                missing_values="NaN", copy=True):
@@ -92,7 +94,7 @@ def masked_euclidean_distances(X, Y=None, squared=False,
         raise ValueError("One or more rows only contain missing values.")
 
     # else:
-    if missing_values not in ["NaN", np.nan] and (
+    if not is_nan(missing_values) and (
             np.any(np.isnan(X)) or (Y is not X and np.any(np.isnan(Y)))):
         raise ValueError(
             "NaN values present but missing_value = {0}".format(


### PR DESCRIPTION
I believe the bug is the same as:

https://github.com/scikit-learn/scikit-learn/issues/11462

Basically, after serializing and deserializing a KNN or Forest imputer, it fails to transform new data, crashing with:

  File "/home/rbowden/.local/share/virtualenvs/qls_py-a_jz9n52/lib/python3.7/site-packages/missingpy/missforest.py", line 505, in transform
    force_all_finite=force_all_finite, copy=self.copy)
  File "/home/rbowden/.local/share/virtualenvs/qls_py-a_jz9n52/lib/python3.7/site-packages/sklearn/utils/validation.py", line 542, in check_array
    allow_nan=force_all_finite == 'allow-nan')
  File "/home/rbowden/.local/share/virtualenvs/qls_py-a_jz9n52/lib/python3.7/site-packages/sklearn/utils/validation.py", line 56, in _assert_all_finite
    raise ValueError(msg_err.format(type_err, X.dtype))
ValueError: Input contains NaN, infinity or a value too large for dtype('float64').

The temporary fix in my code had been:

imputer.missing_values = np.nan

But I believe this patch fixes the issue within missingpy itself (or at least, fixes that particular issue on my end).