### PR TITLE
Update name to sklearn.neighbors.base

### DIFF
--- a/missingpy/knnimpute.py
+++ b/missingpy/knnimpute.py
@@ -10,8 +10,8 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import FLOAT_DTYPES
-from sklearn.neighbors.base import _check_weights
-from sklearn.neighbors.base import _get_weights
+from sklearn.neighbors._base import _check_weights
+from sklearn.neighbors._base import _get_weights
 
 from .pairwise_external import pairwise_distances
 from .pairwise_external import _get_mask


### PR DESCRIPTION
Previous sklearn.neighbors.base has been renamed to sklearn.neighbors._base in version 0.22.1.