### PR TITLE
Removed Deprecated Stuff

### DIFF
--- a/missingpy/knnimpute.py
+++ b/missingpy/knnimpute.py
@@ -10,8 +10,8 @@ from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 from sklearn.utils.validation import FLOAT_DTYPES
-from sklearn.neighbors.base import _check_weights
-from sklearn.neighbors.base import _get_weights
+from sklearn.neighbors._base import _check_weights
+from sklearn.neighbors._base import _get_weights
 
 from .pairwise_external import pairwise_distances
 from .pairwise_external import _get_mask

--- a/missingpy/missforest.py
+++ b/missingpy/missforest.py
@@ -82,7 +82,7 @@ class MissForest(BaseEstimator, TransformerMixin):
         If True, a copy of X will be created. If False, imputation will
         be done in-place whenever possible.
 
-    criterion : tuple, optional (default = ('mse', 'gini'))
+    criterion : tuple, optional (default = ('squared_error', 'gini'))
         The function to measure the quality of a split.The first element of
         the tuple is for the Random Forest Regressor (for imputing numerical
         variables) while the second element is for the Random Forest
@@ -235,7 +235,7 @@ class MissForest(BaseEstimator, TransformerMixin):
     """
 
     def __init__(self, max_iter=10, decreasing=False, missing_values=np.nan,
-                 copy=True, n_estimators=100, criterion=('mse', 'gini'),
+                 copy=True, n_estimators=100, criterion=('squared_error', 'gini'),
                  max_depth=None, min_samples_split=2, min_samples_leaf=1,
                  min_weight_fraction_leaf=0.0, max_features='auto',
                  max_leaf_nodes=None, min_impurity_decrease=0.0,


### PR DESCRIPTION
- Criterion “mse” was deprecated in v1.0 so replaced it with "squared_error"
- Module "sklearn.neighbors.base" has been changed to "sklearn.neighbors._base" so updated it